### PR TITLE
fix: global object conflicting property descriptors

### DIFF
--- a/__tests__/esm/import.test.ts
+++ b/__tests__/esm/import.test.ts
@@ -102,6 +102,26 @@ export default code
     expect(res.cwd).toBe(process.cwd())
   })
 
+  it('should work with provided globals defined by accessors in the current global', async () => {
+    const OriginalBuffer = Buffer
+    Object.defineProperty(global, 'Buffer', {
+      get: () => OriginalBuffer,
+      set: () => {
+        // ok
+      }
+    })
+    try {
+      const res = await importFromString('export const bufferType = typeof Buffer;', {
+        globals: { Buffer }
+      })
+      expect(res.bufferType).toBe('function')
+    } finally {
+      Object.defineProperty(global, 'Buffer', {
+        value: OriginalBuffer
+      })
+    }
+  })
+
   it('should have access the global object', async () => {
     const res = await importFromString('export const { greet } = global', {
       globals: { greet: 'hi' }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,8 +96,13 @@ export const createGlobalObject = (globals: Context, useCurrentGlobal: boolean):
       })
   forEachPropertyKey(globals, propertyKey => {
     if (propertyKey in __GLOBAL__) {
+      const descriptor = Object.getOwnPropertyDescriptor(__GLOBAL__, propertyKey)
+      if (descriptor !== undefined) {
+        delete descriptor.get
+        delete descriptor.set
+      }
       Object.defineProperty(globalObject, propertyKey, {
-        ...Object.getOwnPropertyDescriptor(__GLOBAL__, propertyKey),
+        ...descriptor,
         value: globals[propertyKey as keyof Context]
       })
     } else {


### PR DESCRIPTION
In the modern versions of `node.js` many globals are defined as properties with accessors, providing them using `globals` parameter just throws an exception.

Here is an example reproduction code:

```
const importedFromString = await importFromString('export const result = typeof Buffer;', {
    globals: { Buffer },
});
```

Here is the error I'm getting:

```
TypeError: Invalid property descriptor. Cannot both specify accessors and a value or writable attribute, #<Object>
```

The problem is that `createGlobalObject()` function extracts property descriptors from the current `global` and adds `value` to it and then adds that property descriptor to the generated global. Problem with it is that `value` cannot co-exist with `get` / `set` method as described here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#set 